### PR TITLE
Add IP range support to `create_host_record`.

### DIFF
--- a/infoblox/infoblox.py
+++ b/infoblox/infoblox.py
@@ -167,14 +167,21 @@ class Infoblox(object):
         :param fqdn: hostname in FQDN
         :return: next available ip
         """
+        # CIDR
         if re.match("^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\/[0-9]+$", address):
             ipv4addr = 'func:nextavailableip:' + address
+
+        # range
+        elif re.match("^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$", address):
+            ipv4addr = 'func:nextavailableip:' + address
+
+        # static
+        elif re.match("^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$", address):
+            ipv4addr = address
+
         else:
-            if re.match("^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$", address):
-                ipv4addr = address
-            else:
-                raise InfobloxBadInputParameter(
-                    'Expected IP or NET address in CIDR format')
+            raise InfobloxBadInputParameter(
+                'Expected IP or NET address in CIDR format')
 
         if payload is None:
             payload = {'name': fqdn,


### PR DESCRIPTION
See https://community.infoblox.com/t5/API-Integration/The-definitive-list-of-REST-examples/td-p/1214

This adds support for an IP range to `create_host_record`. This is necessary because, by convention or policy, the first 10 IPs in a range are reserved. CIDR format does not permit that kind of range.
