### PR TITLE
Single root exception heirarchy ftw

### DIFF
--- a/infoblox/infoblox.py
+++ b/infoblox/infoblox.py
@@ -18,27 +18,31 @@ import requests
 import json
 
 
-class InfobloxNotFoundException(Exception):
+class InfobloxException(Exception):
     pass
 
 
-class InfobloxNotUpdatedException(Exception):
+class InfobloxNotFoundException(InfobloxException):
     pass
 
 
-class InfobloxNoIPavailableException(Exception):
+class InfobloxNotUpdatedException(InfobloxException):
     pass
 
 
-class InfobloxNoNetworkAvailableException(Exception):
+class InfobloxNoIPavailableException(InfobloxException):
     pass
 
 
-class InfobloxGeneralException(Exception):
+class InfobloxNoNetworkAvailableException(InfobloxException):
     pass
 
 
-class InfobloxBadInputParameter(Exception):
+class InfobloxGeneralException(InfobloxException):
+    pass
+
+
+class InfobloxBadInputParameter(InfobloxException):
     pass
 
 
@@ -159,9 +163,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def create_host_record(self, address, fqdn, payload=None):
         """ Implements IBA REST API call to create IBA host record
@@ -227,9 +229,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def create_txt_record(self, text, fqdn):
         """ Implements IBA REST API call to create IBA txt record
@@ -252,9 +252,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def delete_host_record(self, fqdn):
         """ Implements IBA REST API call to delete IBA host record
@@ -294,9 +292,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def delete_txt_record(self, fqdn):
         """ Implements IBA REST API call to delete IBA TXT record
@@ -336,9 +332,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def add_host_alias(self, host_fqdn, alias_fqdn):
         """ Implements IBA REST API call to add an alias to IBA host record
@@ -386,9 +380,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def delete_host_alias(self, host_fqdn, alias_fqdn):
         """ Implements IBA REST API call to add an alias to IBA host record
@@ -439,9 +431,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def create_cname_record(self, canonical, name):
         """ Implements IBA REST API call to create IBA cname record
@@ -463,9 +453,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def delete_cname_record(self, fqdn):
         """ Implements IBA REST API call to delete IBA cname record
@@ -503,9 +491,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def update_cname_record(self, canonical, name):
         """ Implements IBA REST API call to update or repoint IBA cname record
@@ -541,9 +527,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def create_dhcp_range(self, start_ip_v4, end_ip_v4):
         """ Implements IBA REST API call to add DHCP range for given
@@ -566,9 +550,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def delete_dhcp_range(self, start_ip_v4, end_ip_v4):
         """ Implements IBA REST API call to delete DHCP range for given
@@ -609,9 +591,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def get_host(self, fqdn, fields=None, notFoundFail=True):
         """ Implements IBA REST API call to retrieve host record fields
@@ -658,9 +638,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def get_txt_by_regexp(self, fqdn):
         """ Implements IBA REST API call to retrieve TXT records by fqdn
@@ -690,9 +668,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def get_host_by_ip(self, ip_v4, fields=None, notFoundFail=True):
         """ Implements IBA REST API call to find hostname by IP address
@@ -751,9 +727,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def get_host_extattrs(self, fqdn, attributes=None):
         """ Implements IBA REST API call to retrieve host extensible attributes
@@ -792,9 +766,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def get_network(self, network, fields=None):
         """ Implements IBA REST API call to retrieve network object fields
@@ -827,9 +799,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def get_network_by_ip(self, ip_v4):
         """ Implements IBA REST API call to find network by IP address which
@@ -858,9 +828,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def get_network_by_extattrs(self, attributes):
         """ Implements IBA REST API call to find a network by it's
@@ -899,9 +867,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def get_host_by_extattrs(self, attributes):
         """ Implements IBA REST API call to find host by it's extensible attributes
@@ -938,9 +904,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def get_network_extattrs(self, network, attributes=None):
         """ Implements IBA REST API call to retrieve network extensible attributes
@@ -980,9 +944,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def update_network_extattrs(self, network, attributes):
         """ Implements IBA REST API call to add or update network extensible attributes
@@ -1030,9 +992,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def delete_network_extattrs(self, network, attributes):
         """ Implements IBA REST API call to delete network extensible attributes
@@ -1078,9 +1038,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def create_network(self, network):
         """ Implements IBA REST API call to create DHCP network object
@@ -1101,9 +1059,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def delete_network(self, network):
         """ Implements IBA REST API call to delete DHCP network object
@@ -1141,9 +1097,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def create_networkcontainer(self, networkcontainer):
         """ Implements IBA REST API call to create DHCP network containert object
@@ -1164,9 +1118,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def delete_networkcontainer(self, networkcontainer):
         """ Implements IBA REST API call to delete DHCP network container object
@@ -1204,9 +1156,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def get_next_available_network(self, networkcontainer, cidr):
         """ Implements IBA REST API call to retrieve next available network
@@ -1252,9 +1202,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def get_a_record_by_ip(self, ipaddr, fields=None, not_found_fail=True):
         """Retrieve A record by IP Address
@@ -1300,9 +1248,7 @@ class Infoblox(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def update_record(self, record, fields, confirm):
         self.util.put(record, fields, confirm)
@@ -1390,9 +1336,7 @@ class Util(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)
 
     def put(self, record, payload, confirm=True):
         """Execute a put operation to update a record.
@@ -1449,6 +1393,4 @@ class Util(object):
                 else:
                     r.raise_for_status()
         except ValueError:
-            raise Exception(r)
-        except Exception:
-            raise
+            raise InfobloxGeneralException(r)


### PR DESCRIPTION
This change unifies the superclass of all exceptions, ensures no generic `Exception`s are raised, and removes the useless raise of a caught `Exception`.
